### PR TITLE
test(lib): Get GitHub Workflow Tests Running

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -22,6 +22,7 @@ jobs:
           submodules: recursive
 
       - name: Run Bats tests
+        shell: 'script -q -e -c "bash {0}"' # work around tty issues
         env:
           TERM: linux
         run: |

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -4,23 +4,18 @@ set -o errexit  # abort on nonzero exit status
 set -o nounset  # abort on unbound variable
 set -o pipefail # don't hide errors within pipes
 
-# Check if bats is installed
-if ! command -v bats &> /dev/null; then
-  echo "Error: bats is not installed." >&2
-  echo "Please install bats. For more information, visit: https://github.com/bats-core/bats-core#installation" >&2
-  exit 1
-fi
-
 # Directory containing the tests
 MY_PATH="$(realpath "${BASH_SOURCE[0]}")"
 readonly MY_PATH
 MY_DIR="$(dirname "${MY_PATH}")"
 readonly MY_DIR
-TEST_DIR="${MY_DIR}/../tests"
-readonly TEST_DIR
+readonly TEST_DIR="${MY_DIR}/../tests"
+readonly BATS_DIR="${TEST_DIR}/bats"
+readonly BATS_BIN_DIR="${BATS_DIR}/bin"
+readonly BATS_EXECUTABLE="${BATS_BIN_DIR}/bats"
 
 # Run bats tests
 echo "Running Bats tests in ${TEST_DIR}"
-bats "${TEST_DIR}"
+"${BATS_EXECUTABLE}" "${TEST_DIR}"
 
 echo "All tests passed"

--- a/demo/console-demo.sh
+++ b/demo/console-demo.sh
@@ -12,47 +12,47 @@ source "${SCRIPT_DIR}/../lib_console.sh"
 # Function Usage
 # ------------------------------------------------------------------------------
 
-debug "This is a debug message."
-info "This is an info message."
-warn "This is a warning message."
-error "This is an error message."
-fatal "This is a fatal message."
+log_debug "This is a debug message."
+log_info "This is an info message."
+log_warn "This is a warning message."
+log_error "This is an error message."
+log_fatal "This is a fatal message."
 
 # ------------------------------------------------------------------------------
 # Pipe Usage (Single Line)
 # ------------------------------------------------------------------------------
 
-echo "This is a debug message." | debug
-echo "This is an info message." | info
-echo "This is a warning message." | warn
-echo "This is an error message." | error
-echo "This is a fatal message." | fatal
+echo "This is a debug message." | log_debug
+echo "This is an info message." | log_info
+echo "This is a warning message." | log_warn
+echo "This is an error message." | log_error
+echo "This is a fatal message." | log_fatal
 
 # ------------------------------------------------------------------------------
 # Pipe Usage (Multi-Line)
 # ------------------------------------------------------------------------------
 
-cat <<EOF | debug
+cat <<EOF | log_debug
 This is a debug message.
 This is the second line.
 EOF
 
-cat <<EOF | info
+cat <<EOF | log_info
 This is an info message.
 This is the second line.
 EOF
 
-cat <<EOF | warn
+cat <<EOF | log_warn
 This is a warning message.
 This is the second line.
 EOF
 
-cat <<EOF | error
+cat <<EOF | log_error
 This is an error message.
 This is the second line.
 EOF
 
-cat <<EOF | fatal
+cat <<EOF | log_fatal
 This is a fatal message.
 This is the second line.
 EOF

--- a/demo/help-demo.sh
+++ b/demo/help-demo.sh
@@ -22,11 +22,11 @@ readonly SEPARATOR
 
 echo "${SEPARATOR}"
 
-(echo "Help for pipe usage without error." | help)
+(echo "Help for pipe usage without error." | print_help)
 
 echo "${SEPARATOR}"
 
-(echo "Help for pipe usage with error." | help "Example error message.")
+(echo "Help for pipe usage with error." | print_help "Example error message.")
 
 # ------------------------------------------------------------------------------
 # Pipe Usage (Multi-Line)
@@ -34,14 +34,14 @@ echo "${SEPARATOR}"
 
 echo "${SEPARATOR}"
 
-cat <<EOF | (help)
+cat <<EOF | (print_help)
 Help for HERE document pipe usage without error.
 Using indirection via 'cat'.
 EOF
 
 echo "${SEPARATOR}"
 
-cat <<EOF | (help "Example error message.")
+cat <<EOF | (print_help "Example error message.")
 Help for HERE document pipe usage with error.
 Using indirection via 'cat'.
 EOF
@@ -49,7 +49,7 @@ EOF
 echo "${SEPARATOR}"
 
 (
-  help <<EOF
+  print_help <<EOF
 Help for HERE document pipe usage without error.
 Using direct call.
 EOF
@@ -58,7 +58,7 @@ EOF
 echo "${SEPARATOR}"
 
 (
-help "Example error message" << EOF
+  print_help "Example error message" <<EOF
 Help for HERE document pipe usage with error.
 Using direct call.
 EOF

--- a/lib_console.sh
+++ b/lib_console.sh
@@ -144,7 +144,7 @@ function _log() {
 # Output:
 #   The message is printed to STDERR.
 # ------------------------------------------------------------------------------
-function debug() {
+function log_debug() {
   if ((DEBUG > 0)); then
     if [[ -t 2 ]]; then
       _log "${COLOR_GRAY}[DEBUG] " "${COLOR_RESET}" "$@"
@@ -172,7 +172,7 @@ function debug() {
 # Output:
 #   The message is printed to STDERR.
 # ------------------------------------------------------------------------------
-function info() {
+function log_info() {
   _log "[INFO] " "" "$@"
 }
 
@@ -189,7 +189,7 @@ function info() {
 # Output:
 #   The message is printed to STDERR.
 # ------------------------------------------------------------------------------
-function warn() {
+function log_warn() {
   if [[ -t 2 ]]; then
     _log "${COLOR_LIGHT_YELLOW}[WARNING] " "${COLOR_RESET}" "$@"
   else
@@ -210,7 +210,7 @@ function warn() {
 # Output:
 #   The message is printed to STDERR.
 # ------------------------------------------------------------------------------
-function error() {
+function log_error() {
   if [[ -t 2 ]]; then
     _log "${COLOR_LIGHT_RED}[ERROR] " "${COLOR_RESET}" "$@"
   else
@@ -231,7 +231,7 @@ function error() {
 # Output:
 #   The message is printed to STDERR.
 # ------------------------------------------------------------------------------
-function fatal() {
+function log_fatal() {
   if [[ -t 2 ]]; then
     _log "${COLOR_BG_RED}${COLOR_LIGHT_YELLOW}[FATAL] " "${COLOR_RESET}" "$@"
   else

--- a/lib_help.sh
+++ b/lib_help.sh
@@ -24,13 +24,13 @@ source "${LIB_HELP_DIR}/lib_init.sh"
 # shellcheck source=/dev/null
 source "${LIB_HELP_DIR}/lib_console.sh"
 
-help() {
+print_help() {
   local error_text="${1:-}"
 
   if [[ -n "${error_text}" ]]; then
     # Must use pipe here, to avoid the subsequent check for pipe input
     # to be triggered accidentally, if `help` is called from a pipe.
-    echo -e "${error_text}" | error
+    echo -e "${error_text}" | log_error
     echo >&2
   fi
 

--- a/tests/lib_console.bats
+++ b/tests/lib_console.bats
@@ -21,8 +21,14 @@ setup() {
   assert_output "[DEBUG] This is a debug message"
 }
 
-@test "info function outputs info message" {
+@test "info function outputs info message (function usage)" {
   run info "This is an info message"
+  assert_success
+  assert_output "[INFO] This is an info message"
+}
+
+@test "info function outputs info message (piped usage)" {
+  run echo "This is an info message" | info
   assert_success
   assert_output "[INFO] This is an info message"
 }

--- a/tests/lib_console.bats
+++ b/tests/lib_console.bats
@@ -8,45 +8,70 @@ setup() {
   source "${BATS_TEST_DIRNAME}/../lib_console.sh"
 }
 
-@test "debug outputs no message by default" {
-  run debug "This is a debug message"
+@test "log_debug outputs no message by default" {
+  run log_debug "This is a debug message"
   assert_success
   [ "${#lines[@]}" -eq 0 ]
 }
 
-@test "debug function outputs debug message when DEBUG is set" {
+@test "log_debug function outputs debug message when DEBUG is set" {
   DEBUG=1
-  run debug "This is a debug message"
+  run log_debug "This is a debug message"
   assert_success
   assert_output "[DEBUG] This is a debug message"
 }
 
-@test "info function outputs info message (function usage)" {
-  run info "This is an info message"
+@test "log_info function outputs info message (function usage)" {
+  run log_info "This is an info message"
   assert_success
   assert_output "[INFO] This is an info message"
 }
 
-@test "info function outputs info message (piped usage)" {
-  run echo "This is an info message" | info
+@test "log_info function outputs info message (piped usage)" {
+  function function_under_test() {
+    echo "This is an info message" | log_info
+  }
+  run function_under_test
   assert_success
   assert_output "[INFO] This is an info message"
 }
 
-@test "warn function outputs warning message" {
-  run warn "This is a warning message"
+@test "log_info function outputs info message (HERE document, piped usage)" {
+  function function_under_test() {
+    cat <<EOF | log_info
+This is an info message
+EOF
+  }
+  run function_under_test
+  assert_success
+  assert_output "[INFO] This is an info message"
+}
+
+@test "log_info function outputs info message (HERE document)" {
+  function function_under_test() {
+    log_info <<EOF
+This is an info message
+EOF
+  }
+  run function_under_test
+  assert_success
+  assert_output "[INFO] This is an info message"
+}
+
+@test "log_warn function outputs warning message" {
+  run log_warn "This is a warning message"
   assert_success
   assert_output "[WARNING] This is a warning message"
 }
 
-@test "error function outputs error message" {
-  run error "This is an error message"
+@test "log_error function outputs error message" {
+  run log_error "This is an error message"
   assert_success
   assert_output "[ERROR] This is an error message"
 }
 
-@test "fatal function outputs fatal message" {
-  run fatal "This is a fatal message"
+@test "log_fatal function outputs fatal message" {
+  run log_fatal "This is a fatal message"
   assert_success
   assert_output "[FATAL] This is a fatal message"
 }


### PR DESCRIPTION
Fix GitHub Workflow Tests, especially by applying workaround from bats-core/bats-core, which is:

```yaml
- name: Run test on OS ${{ matrix.os }}
  shell: 'script -q -e -c "bash {0}"' # work around tty issues
  env:
    TERM: linux # fix tput for tty issue work around
  run: |
    bash --version
    bash -c "time ${{ matrix.env_vars }} bin/bats --print-output-on-failure --formatter tap test"
```

This change also includes renaming the logging functions with a prefix `log_` to prevent collisions with the `info` command (detected by accident during experiments).